### PR TITLE
added encoding for error in details

### DIFF
--- a/espeak_sings.py
+++ b/espeak_sings.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-
+# -*- coding: UTF8 -*-
 # Copyright © 2015 Keefer Rourke <keefer.rourke@gmail.com>
 # <https://krourke.org>
 #


### PR DESCRIPTION
File "espeak_sings.py", line 3
SyntaxError: Non-ASCII character '\xc2' in file espeak_sings.py on line 3, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details